### PR TITLE
Push timestamped builds to a dev repo

### DIFF
--- a/.settings.xml
+++ b/.settings.xml
@@ -5,5 +5,10 @@
       <username>${env.ATOMIST_REPO_USER}</username>
       <password>${env.ATOMIST_REPO_TOKEN}</password>
     </server>
+    <server>
+      <id>public-atomist-dev</id>
+      <username>${env.ATOMIST_REPO_USER}</username>
+      <password>${env.ATOMIST_REPO_TOKEN}</password>
+    </server>
   </servers>
 </settings>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+sudo: false
 language: java
 install: true
 script: bash travis-build.bash

--- a/travis-build.bash
+++ b/travis-build.bash
@@ -16,10 +16,17 @@ $mvn install -Dmaven.javadoc.skip=true
 echo "Branch is ${TRAVIS_BRANCH}"
 
 [[ $TRAVIS_PULL_REQUEST == false ]] || exit 0
-[[ $project_version ]] || exit 0
+
 if [[ $TRAVIS_BRANCH == master || $TRAVIS_TAG =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    if [[ ! $project_version ]]; then
+        echo "Unable to determine version"
+        exit 1
+    fi
     echo "Version is $project_version"
-    $mvn deploy -DskipTests
+    if [[ $TRAVIS_BRANCH == master ]]; then
+        mvn_deploy_args=-DaltDeploymentRepository=public-atomist-dev::default::https://atomist.jfrog.io/atomist/libs-dev-local
+    fi
+    $mvn deploy -DskipTests $mvn_deploy_args
     git config --global user.email "travis-ci@atomist.com"
     git config --global user.name "Travis CI"
     git_tag=$project_version+travis$TRAVIS_BUILD_NUMBER


### PR DESCRIPTION
The dev repo must be a maven repo that handle releases.  We define the
alternate repo on the mvn command line, but the authentication
information for the repo must be in .settings.xml

Sneak in a move the the Travis CI trusty image.

@cdupuis here is the model for pushing timestamped builds to a different repo. Merge if you approve and I can start work on the Rug Editor.